### PR TITLE
A better condition for running test-c in any buffer

### DIFF
--- a/test-c.el
+++ b/test-c.el
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
 (defun test-c (new-buffer)
   "Compile and run a new test-c buffer (or reuse existing one)."
   (interactive "P")
-  (when (not test-c-buffer)
+  (when (not (bound-and-true-p test-c-mode))
     (switch-to-buffer (get-buffer-create "*test-c*"))
     (when (string= (buffer-string) "")
       (erase-buffer)


### PR DESCRIPTION
Running test-c in any buffer opens up the default "*test-c*" buffer and compiles
it instead of the other buffer. Now, we can use the current buffer to compile
the program only iff test-c-mode is ON for that buffer.